### PR TITLE
Update API to new orchestrator protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # py_lstm
-LSTM model for the outlier Classifier
+LSTM model for the outlier classifier. Implements the node protocol used by the orchestrator to manage training and prediction.
+
+### Endpoints
+
+- `GET /health` – reports node status.
+- `POST /train` – initiates a training session.
+- `POST /train/{ordinal}` – streams discharges for training.
+- `POST /predict` – predicts disruption for a single discharge.


### PR DESCRIPTION
## Summary
- implement new training session workflow with `/train` and `/train/{ordinal}`
- simplify `/predict` to accept a single discharge
- update health endpoint to return node name, uptime and last training time
- add webhook callback when training finishes
- document updated endpoints in README

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6855a4b8ab14832898c311837be52e7a