### PR TITLE
Update endpoints to Outlier protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # py_lstm
-LSTM model for the outlier Classifier
+LSTM model for the outlier Classifier.
+
+This service exposes a REST API compatible with the Outlier protocol. Key endpoints:
+
+- `GET /health` – basic node health information.
+- `POST /train` and `POST /train/{ordinal}` – training workflow where discharges
+  are pushed sequentially.
+- `POST /predict` – run a prediction on a single discharge.


### PR DESCRIPTION
## Summary
- update the REST API to implement the new Outlier protocol
- support sequential training workflow with `/train` and `/train/{ordinal}`
- adjust prediction endpoint to accept a single discharge
- simplify `health` output and remove unused memory info
- document new endpoints in README

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6855a4b8ab14832898c311837be52e7a